### PR TITLE
12.0 mig tare pad improvements

### DIFF
--- a/pos_tare/__manifest__.py
+++ b/pos_tare/__manifest__.py
@@ -9,7 +9,9 @@
     "website": "https://github.com/OCA/pos",
     "license": "AGPL-3",
     "maintainers": ["fkawala"],
-    "depends": ["point_of_sale"],
+    "depends": [
+        "point_of_sale",
+        "base_fontawesome"],
     "data": [
         "views/templates.xml",
         "views/view_pos_config.xml",

--- a/pos_tare/models/pos_config.py
+++ b/pos_tare/models/pos_config.py
@@ -4,7 +4,8 @@ from odoo import api, models, fields
 class PosConfig(models.Model):
     _inherit = "pos.config"
 
-    iface_tare_method = fields.Selection([
+    iface_tare_method = fields.Selection(
+        [
             ("manual", "Input the tare manually"),
             ("barcode", "Scan a barcode to set the tare"),
             ("both", "Manual input and barcode"),
@@ -18,7 +19,8 @@ class PosConfig(models.Model):
         "* 'both' : manual input and barcode methods are enabled;",
     )
 
-    iface_gross_weight_method = fields.Selection([
+    iface_gross_weight_method = fields.Selection(
+        [
             ("manual", "Input the Gross Weight manually"),
             ("scale", "Input Gross Weight via Scale")
         ],

--- a/pos_tare/static/src/js/models.js
+++ b/pos_tare/static/src/js/models.js
@@ -4,34 +4,7 @@ odoo.define('pos_tare.models', function (require) {
     var core = require('web.core');
     var models = require('point_of_sale.models');
     var pos_tare_tools = require('pos_tare.tools');
-
     var _t = core._t;
-
-    class ValidationError extends Error {
-        constructor(message, gui) {
-            super(message); // (1)
-            this.name = "ValidationError"; // (2)
-            this.gui = gui;
-        }
-    }
-
-    var _NumpadState_ = models.NumpadState.prototype;
-    var NumpadState = models.NumpadState.extend({
-        appendNewChar: function (newChar) {
-            try {
-                _NumpadState_.appendNewChar.call(this, newChar);
-            } catch (error) {
-                if (error instanceof ValidationError) {
-                    var title = _t("Error while applying the numpad action");
-                    var popup = {title: title, body: error.message};
-                    error.gui.show_popup('error', popup);
-                    _NumpadState_.deleteLastChar.call(this);
-                } else {
-                  throw error;
-                }
-            }
-        },
-    });
 
     var _super_ = models.Orderline.prototype;
     var OrderLineWithTare = models.Orderline.extend({
@@ -95,16 +68,6 @@ odoo.define('pos_tare.models', function (require) {
                 this.pos, tare_in_product_uom, line_unit);
             if (update_net_weight) {
                 var net_quantity = this.get_quantity() - tare_in_product_uom;
-                // This method fails when the net weight is negative.
-                if (net_quantity <= 0) {
-                    throw new ValidationError(_.str.sprintf(
-                        _t("The tare weight is %s %s, it's greater or equal" +
-                        " to the gross weight %s. To apply this tare would" +
-                        " result in a negative net weight and a negative" +
-                        " price. This tare can not be applied to this item."),
-                        tare_in_product_uom_string, line_unit.name,
-                        this.get_quantity_str_with_unit()), this.pos.gui);
-                }
                 // Update the quantity with the new weight net of tare quantity.
                 this.set_quantity(net_quantity);
             }
@@ -148,8 +111,6 @@ odoo.define('pos_tare.models', function (require) {
 
     });
 
-
-    models.NumpadState = NumpadState;
     models.Orderline = OrderLineWithTare;
 
 });

--- a/pos_tare/static/src/js/screens.js
+++ b/pos_tare/static/src/js/screens.js
@@ -147,8 +147,8 @@ odoo.define('pos_tare.screens', function (require) {
                     title: _t('Quantity lower or equal to zero'),
                     body:  _.str.sprintf(
                         _t("The quantity for \"%s\" is lower or equal to" +
-                        " zero. Call for help unless your perfectly sure " +
-                        " about what you are doing."), wrong_product),
+                        " zero. Call for help unless you're perfectly" +
+                        " sure you are doing right."), wrong_product),
                     confirm: function() {
                         _super_validate_order();
                     },

--- a/pos_tare/static/src/xml/pos_tare.xml
+++ b/pos_tare/static/src/xml/pos_tare.xml
@@ -31,7 +31,7 @@
         <t t-jquery=".info-list:last-child" t-operation="append">
             <t t-if="line.get_tare() !== 0">
                 <li class="info">
-                    <i class="fa fa-beer"/>
+                    <i class="fas fa-prescription-bottle"></i>
                     Tare :
                     <t t-esc="line.get_tare_str_with_unit()"/>
                 </li>

--- a/pos_tare/static/src/xml/pos_tare.xml
+++ b/pos_tare/static/src/xml/pos_tare.xml
@@ -71,13 +71,15 @@
                       </t>
                       <line indent='1'>
                           <left>
-                              <value t-att-value-decimals='pos.dp["Product Unit of Measure"]' value-autoint='on'>
                                 <t t-if="line.tare_quantity !== 0">
-                                  <t t-esc="line.gross_quantity" /> -
-                                  <t t-esc="line.tare_quantity"/> =
+                                  <value t-att-value-decimals='pos.dp["Product Unit of Measure"]' value-autoint='on'>
+                                    <t t-esc="line.gross_quantity" />
+                                  </value> -
+                                  <value t-att-value-decimals='pos.dp["Product Unit of Measure"]' value-autoint='on'>
+                                    <t t-esc="line.tare_quantity"/>
+                                  </value> =
                                 </t>
                                   <t t-esc='line.quantity' />
-                              </value>
                               <t t-if='line.unit_name !== "Unit(s)"'>
                                   <t t-esc='line.unit_name' />
                               </t>


### PR DESCRIPTION
@legalsylvain, j'ai:
- [x] Bougé l'erreur quand une tare implique un poids net nul ou négatif dans la validation du panier.
- [x] Changé le fonctionnement du bouton QTY pour que celui-ci change le "gross weight" et conserve la tare.
- [ ] Essayé **sans succès** d'utiliser `base_fontawesome` pour passer de l'icone de bière à https://fontawesome.com/v5.7.1/icons/prescription-bottle?style=solid.

Qu'en penses tu ? Merci !