### PR TITLE
12.0 mig tare imp

### DIFF
--- a/pos_tare/__init__.py
+++ b/pos_tare/__init__.py
@@ -1,1 +1,1 @@
-from . import models  # noqa: F401
+from . import models

--- a/pos_tare/__manifest__.py
+++ b/pos_tare/__manifest__.py
@@ -11,7 +11,7 @@
     "maintainers": ["fkawala"],
     "depends": [
         "point_of_sale",
-        "base_fontawesome"],
+    ],
     "data": [
         "views/templates.xml",
         "views/view_pos_config.xml",

--- a/pos_tare/__manifest__.py
+++ b/pos_tare/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "GRAP, Le Nid, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pos",
     "license": "AGPL-3",
-    "maintainers": ["fkawala"],
+    "maintainers": ["fkawala", "legalsylvain"],
     "depends": [
         "point_of_sale",
     ],

--- a/pos_tare/models/__init__.py
+++ b/pos_tare/models/__init__.py
@@ -1,3 +1,3 @@
-from . import pos_config  # noqa: F401
-from . import pos_order_line  # noqa: F401
-from . import barcode_rule  # noqa: F401
+from . import pos_config
+from . import pos_order_line
+from . import barcode_rule

--- a/pos_tare/static/src/css/pos_tare.css
+++ b/pos_tare/static/src/css/pos_tare.css
@@ -1,3 +1,25 @@
+/***************************************************************
+Overloading existing PoS objects
+****************************************************************/
+
+/*Change the design of the numpad in the product-screen*/
+.pos .product-screen .actionpad .button.pay {
+    height: 216px;
+}
+
+.pos .product-screen .numpad button.input-button.numpad-backspace {
+    width: 216px;
+}
+
+/*Fix the receipt in the non proxy mode as the order lines can now
+content multiple lines*/
+.pos .pos-right-align{
+    vertical-align: top;
+}
+
+/***************************************************************
+New style for new scale objects
+****************************************************************/
 
 .pos .scale-screen .weight-label {
     font-size: 25px;
@@ -46,12 +68,4 @@
 .pos .scale-screen .input-weight:focus {
     outline: none;
     box-shadow: 0px 0px 0px 3px #6EC89B;
-}
-
-.pos .actionpad .button.pay {
-    height: 216px;
-}
-
-.pos .numpad button.input-button.numpad-backspace {
-    width: 216px;
 }

--- a/pos_tare/static/src/xml/pos_tare.xml
+++ b/pos_tare/static/src/xml/pos_tare.xml
@@ -56,47 +56,21 @@
     </t>
 
     <t t-name="XmlReceipt" t-extend="XmlReceipt">
-        <t t-jquery=".orderlines" t-operation="inner">
-              <t t-foreach='receipt.orderlines' t-as='line'>
-                  <t t-set='simple' t-value='line.discount === 0 and line.unit_name === "Unit(s)" and line.quantity === 1' />
-                  <t t-if='simple'>
-                      <line>
-                          <left><t t-esc='line.product_name_wrapped[0]' /></left>
-                          <right><value t-att-value-decimals='pos.currency.decimals'><t t-esc='line.price_display' /></value></right>
-                      </line>
-                      <t t-call="XmlReceiptWrappedProductNameLines"/>
-                  </t>
-                  <t t-if='!simple'>
-                      <line><left><t t-esc='line.product_name_wrapped[0]' /></left></line>
-                      <t t-call="XmlReceiptWrappedProductNameLines"/>
-                      <t t-if='line.discount !== 0'>
-                          <line indent='1'><left>Discount: <t t-esc='line.discount' />%</left></line>
-                      </t>
-                      <line indent='1'>
-                          <left>
-                                <t t-if="line.tare_quantity !== 0">
-                                  <value t-att-value-decimals='pos.dp["Product Unit of Measure"]' value-autoint='on'>
-                                    <t t-esc="line.gross_quantity" />
-                                  </value> -
-                                  <value t-att-value-decimals='pos.dp["Product Unit of Measure"]' value-autoint='on'>
-                                    <t t-esc="line.tare_quantity"/>
-                                  </value> =
-                                </t>
-                                  <t t-esc='line.quantity' />
-                              <t t-if='line.unit_name !== "Unit(s)"'>
-                                  <t t-esc='line.unit_name' />
-                              </t>
-                              x
-                              <value t-att-value-decimals='pos.dp["Product Price"]'>
-                                  <t t-esc='line.price' />
-                              </value>
-                          </left>
-                          <right>
-                              <value t-att-value-decimals='pos.currency.decimals'><t t-esc='line.price_display' /></value>
-                          </right>
-                      </line>
-                  </t>
-              </t>
+        <t t-jquery="t[t-if='!simple']" t-operation="append">
+            <t t-if="line.tare_quantity !== 0">
+                <line indent='1'>
+                    <left>
+                        (
+                        <value t-att-value-decimals='pos.dp["Product Unit of Measure"]' value-autoint='on'>
+                          <t t-esc="line.gross_quantity" />
+                        </value> -
+                        <value t-att-value-decimals='pos.dp["Product Unit of Measure"]' value-autoint='on'>
+                          <t t-esc="line.tare_quantity"/>
+                        </value>
+                        )
+                    </left>
+                </line>
+            </t>
         </t>
     </t>
 

--- a/pos_tare/static/src/xml/pos_tare.xml
+++ b/pos_tare/static/src/xml/pos_tare.xml
@@ -31,9 +31,12 @@
         <t t-jquery=".info-list:last-child" t-operation="append">
             <t t-if="line.get_tare() !== 0">
                 <li class="info">
-                    <i class="fas fa-prescription-bottle"></i>
-                    Tare :
-                    <t t-esc="line.get_tare_str_with_unit()"/>
+                    <i>
+                      (Gross Weight:
+                      <em><t t-esc="line.get_gross_weight_str_with_unit()"/></em>
+                      - Tare:
+                      <em><t t-esc="line.get_tare_str_with_unit()"/></em>)
+                    </i>
                 </li>
             </t>
         </t>


### PR DESCRIPTION
supersed : https://github.com/Fkawala/pos/pull/4/

- [FIX] remove useless noqa

noqa is unnecessary in ``__init__.py`` files because F401 is ignored for such files.

 - [FIX] do not break numpad widget present in the payment screen

little improvement in the css. before this patch, the numpad in the payment screen had a bug.

-  [IMP] display gross and tare weight for each line ; [REM] remove dependency to base_fontawesome

I added gross weight under each line. It improves User experience when user is typing manually the gross weight, in the main screen. He see what he's doing.

-  [IMP] ticket (proxy mode) : do not break inheritance 

I made some simplification in the code. the previous code was overwritting the ticket. So the price unit was not displayed for line with tare. The new code is lighter, and just add a new line (Gross weight - Tare).





